### PR TITLE
BodySprite support for material blending mode

### DIFF
--- a/src/initializer/constants.js
+++ b/src/initializer/constants.js
@@ -3,7 +3,11 @@ import { AdditiveBlending } from 'three';
 export const DEFAULT_MATERIAL_PROPERTIES = {
   color: 0xff0000,
   blending: AdditiveBlending,
-  fog: true
+  fog: true,
+};
+export const DEFAULT_JSON_MATERIAL_PROPERTIES = {
+  ...DEFAULT_MATERIAL_PROPERTIES,
+  blending: 'AdditiveBlending',
 };
 export const DEFAULT_RATE_NUM_PAN = 1;
 export const DEFAULT_RATE_TIME_PAN = 1;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,3 +3,8 @@ export { default as PUID } from './PUID';
 export { default as THREEUtil } from './THREEUtil';
 export { default as Util } from './Util';
 export { default as uid } from './uid';
+
+export const withDefaults = (defaults, properties) => ({
+  ...defaults,
+  ...properties,
+});

--- a/test/initializer/BodySprite.spec.js
+++ b/test/initializer/BodySprite.spec.js
@@ -2,7 +2,9 @@
 
 import * as Proton from '../../src';
 
-import { TextureLoader } from 'three';
+import { NormalBlending, TextureLoader } from 'three';
+
+import { DEFAULT_MATERIAL_PROPERTIES } from '../../src/initializer/constants';
 import chai from 'chai';
 import domino from 'domino';
 import sinon from 'sinon';
@@ -31,21 +33,42 @@ describe('initializer -> BodySprite', () => {
     done();
   });
 
-  it('should construct the initializer from a JSON object', done => {
+  it('should construct the initializer from a JSON object and set the default blending mode', done => {
     const textureLoaderSpy = spy(TextureLoader.prototype, 'load');
     const instance = Proton.BodySprite.fromJSON({
       texture,
       materialProperties: {
         fog: false,
-        color: 0xffffff,
+        color: 0xffff33,
       },
     });
 
     assert.instanceOf(instance, Proton.BodySprite);
+    assert.strictEqual(
+      instance.materialProperties.blending,
+      DEFAULT_MATERIAL_PROPERTIES.blending
+    );
     assert(textureLoaderSpy.calledOnceWith(texture));
     assert.isTrue(instance.isEnabled);
 
     textureLoaderSpy.restore();
+
+    done();
+  });
+
+  it('should set the material blending properties correctly when loaded from a JSON object', done => {
+    const instance = Proton.BodySprite.fromJSON({
+      texture,
+      materialProperties: {
+        fog: false,
+        color: 0xffffff,
+        blending: 'NormalBlending',
+      },
+    });
+
+    assert.instanceOf(instance, Proton.BodySprite);
+    assert.strictEqual(instance.materialProperties.blending, NormalBlending);
+
     done();
   });
 });


### PR DESCRIPTION
### Added 

* The ability to set mesh material blending mode correctly from a string via the `fromJSON` method for the `BodySprite` initialiser
* Unit test covering this