### PR TITLE
feature/better-proton-destroy

### DIFF
--- a/src/core/Proton.js
+++ b/src/core/Proton.js
@@ -39,6 +39,13 @@ export default class Proton {
     this.type = type;
 
     /**
+     * @desc Determines if the system can update or not. Set to false when destroying
+     * to ensure that external calls to update do not throw errors.
+     * @type {boolean}
+     */
+    this.canUpdate = true;
+
+    /**
      * @desc The number of particles to start with.
      * @type {number}
      */
@@ -191,17 +198,19 @@ export default class Proton {
   update(delta = DEFAULT_PROTON_DELTA) {
     const d = delta || DEFAULT_PROTON_DELTA;
 
-    this.dispatch(PROTON_UPDATE);
+    if (this.canUpdate) {
+      this.dispatch(PROTON_UPDATE);
 
-    if (d > 0) {
-      let i = this.emitters.length;
+      if (d > 0) {
+        let i = this.emitters.length;
 
-      while (i--) {
-        this.emitters[i].update(d);
+        while (i--) {
+          this.emitters[i].update(d);
+        }
       }
-    }
 
-    this.dispatch(PROTON_UPDATE_AFTER);
+      this.dispatch(PROTON_UPDATE_AFTER);
+    }
 
     return Promise.resolve();
   }
@@ -225,19 +234,23 @@ export default class Proton {
 
   /**
    * Destroys all emitters and the Proton pool.
+   * Ensures that this.update will not perform any operations while the system
+   * is being destroyed.
    *
    * @return void
    */
   destroy() {
     const length = this.emitters.length;
-    let i = 0;
 
-    for (i; i < length; i++) {
-      this.emitters[i].destroy();
+    this.canUpdate = false;
+
+    for (let i = 0; i < length; i++) {
+      this.emitters[i] && this.emitters[i].destroy();
       delete this.emitters[i];
     }
 
     this.emitters.length = 0;
     this.pool.destroy();
+    this.canUpdate = true;
   }
 }

--- a/test/core/Proton.spec.js
+++ b/test/core/Proton.spec.js
@@ -6,7 +6,7 @@ import EventDispatcher, {
   EMITTER_ADDED,
   EMITTER_REMOVED,
   PROTON_UPDATE,
-  PROTON_UPDATE_AFTER
+  PROTON_UPDATE_AFTER,
 } from '../../src/events';
 
 import { INTEGRATION_TYPE_EULER } from '../../src/math';
@@ -27,7 +27,7 @@ describe('core -> Proton', () => {
       emitters,
       renderers,
       pool,
-      eventDispatcher
+      eventDispatcher,
     } = new System();
 
     assert.equal(type, 'Proton');
@@ -127,6 +127,28 @@ describe('core -> Proton', () => {
 
     emitterSpy.restore();
     dispatchSpy.restore();
+
+    done();
+  });
+
+  it('should not dispatch from within the update method if the canUpdate prop is set to false', done => {
+    const proton = new System();
+    const emitter = new Proton.Emitter();
+
+    proton.canUpdate = false;
+    proton.addEmitter(emitter);
+
+    // add spies here so that the dispatch in addEmitter isn't spied on
+    const emitterUpdateSpy = sinon.spy(emitter, 'update');
+    const dispatchSpy = sinon.spy(proton, 'dispatch');
+
+    proton.update();
+
+    assert(dispatchSpy.notCalled);
+    assert(emitterUpdateSpy.notCalled);
+
+    dispatchSpy.restore();
+    emitterUpdateSpy.restore();
 
     done();
   });


### PR DESCRIPTION
### Added 

* `canUpdate` property to the core particle system class 

### Changed 

* The `canUpdate` property is now checked within the `update` method to ensure safe updates 
* `destroy` now toggles the `canUpdate` property internally to ensure that emitter updates are blocked while destroying to prevent errors occurring when destroying a system that is animating